### PR TITLE
Added "amount of drawing" dropdown and filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,11 +33,13 @@ function App() {
     7: true,
     drawful2: true
   });
+  const [drawingSelect, setDrawingSelect] = useState<any>({
+    drawing: ["any"]
+  });
   const [filterChecks, setFilterChecks] = useState<any>({
     extended_timers: false,
     family_mode: false,
-    audience: false,
-    drawing: false
+    audience: false
   });
 
   const hideMobileCell = "d-none d-md-table-cell";
@@ -58,6 +60,10 @@ function App() {
     setjbGames({...jbGames, [newValue.name] : newValue.checked });
   }
 
+  const handleDrawingSelectChange = (newValue: any) => {
+    setDrawingSelect({...drawingSelect, drawing : newValue.value.split('|') });
+  }
+
   const handleFilterChecksChange = (newValue: any) => {
     setFilterChecks({...filterChecks, [newValue.name] : newValue.checked });
   }
@@ -67,10 +73,12 @@ function App() {
   }).filter((game) => {
     return jbGames[game.pack];
   }).filter((game) => {
+    return drawingSelect.drawing.includes("any") ||
+      drawingSelect.drawing.includes(game.drawing);
+  }).filter((game) => {
     return (!filterChecks.extended_timers || game.extended_timers) &&
       (!filterChecks.family_mode || game.family_mode) &&
-      (!filterChecks.audience || game.audience) &&
-      (!filterChecks.drawing || game.drawing);
+      (!filterChecks.audience || game.audience);
   });
 
   return (
@@ -94,6 +102,8 @@ function App() {
                     onPlayersChange={handlePlayersChange}    
                     onJbGamesChange={handleJbGamesChange}
                     jbGames={jbGames}
+                    drawingSelect={drawingSelect}
+                    onDrawingSelectChange={handleDrawingSelectChange}
                     filterChecks={filterChecks}
                     onFilterChecksChange={handleFilterChecksChange}        
                   />

--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -8,6 +8,8 @@ const Filter: React.FC<Types.FilterInterface> = (
     onPlayersChange,
     onJbGamesChange,
     jbGames,
+    drawingSelect,
+    onDrawingSelectChange,
     filterChecks,
     onFilterChecksChange }
   ) => {
@@ -24,6 +26,10 @@ const Filter: React.FC<Types.FilterInterface> = (
 
   function handleJbGamesChange(event: any) {
     onJbGamesChange(event.target);
+  }
+
+  function handleDrawingSelectChange(event: any) {
+    onDrawingSelectChange(event.target);
   }
 
   function handleFilterChecksChange(event: any) {
@@ -88,11 +94,6 @@ const filterCheckboxes = [
     name: 'audience',
     key: 'audience',
     label: 'Audience',
-  },
-  {
-    name: 'drawing',
-    key: 'drawing',
-    label: 'Drawing involved',
   }
 ];
 
@@ -123,6 +124,18 @@ const filterCheckboxes = [
           placeholder="Number of players"
           aria-label="Number of players"
         />
+      </Form.Group>
+      <Form.Group>
+        <Form.Control as="select"
+          onChange={handleDrawingSelectChange}
+          type="select"
+        >
+          <option value="any">Don't filter games based on amount of drawing</option>
+          <option value="no">Show only games with no drawing</option>
+          <option value="no|occasionally">Show only games with no or occasional drawing</option>
+          <option value="occasionally|primarily">Show only games with occasional drawing or which are primarily drawing</option>
+          <option value="primarily">Show only games which are primarily drawing</option>
+        </Form.Control>
       </Form.Group>
       Hide games that don't have:
       <Form.Group>

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -60,7 +60,7 @@ const Game: React.FC<Types.GamesAppInterface> = (
         {BooleanEmoji(audience)}
       </td>
       <td className="d-none d-md-table-cell">
-        {BooleanEmoji(drawing)}
+        {drawing}
       </td>
     </tr>
   );

--- a/src/data/data.json
+++ b/src/data/data.json
@@ -9,7 +9,7 @@
     "img": "ydkj2015.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 331670
   },
@@ -23,7 +23,7 @@
     "img": "fibbagexl.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 331670
   },
@@ -37,7 +37,7 @@
     "img": "drawful.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 331670
   },
@@ -51,7 +51,7 @@
     "img": "word.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "steam_id": 331670
   },
   {
@@ -64,7 +64,7 @@
     "img": "lie.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "steam_id": 331670
   },
   {
@@ -77,7 +77,7 @@
     "img": "fibbage2.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 397460
   },
@@ -91,7 +91,7 @@
     "img": "ear.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 397460
   },
@@ -105,7 +105,7 @@
     "img": "bid.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 397460
   },
@@ -119,7 +119,7 @@
     "img": "quipxl.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 397460
   },
@@ -133,7 +133,7 @@
     "img": "bomb.jpg",
     "family_mode": false,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 397460
   },
@@ -147,7 +147,7 @@
     "img": "quip2.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 434170
   },
@@ -161,7 +161,7 @@
     "img": "tmp.jpg",
     "family_mode": false,
     "audience": true,
-    "drawing": true,
+    "drawing": "occasionally",
     "game_length": 20,
     "steam_id": 434170
   },
@@ -175,7 +175,7 @@
     "img": "guess.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 434170
   },
@@ -189,7 +189,7 @@
     "img": "fakin.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 434170
   },
@@ -203,7 +203,7 @@
     "img": "teeko.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 30,
     "steam_id": 434170
   },
@@ -217,7 +217,7 @@
     "img": "fibbage3.png",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 610180
   },
@@ -231,7 +231,7 @@
     "img": "survive.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 610180
   },
@@ -245,7 +245,7 @@
     "img": "monster.jpg",
     "family_mode": false,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 610180
   },
@@ -259,7 +259,7 @@
     "img": "bracket.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 610180
   },
@@ -273,7 +273,7 @@
     "img": "civic.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 610180
   },
@@ -287,7 +287,7 @@
     "img": "ydkjfs.png",
     "family_mode": false,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 774461
   },
@@ -301,7 +301,7 @@
     "img": "split.png",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 774461
   },
@@ -315,7 +315,7 @@
     "img": "mad.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 20,
     "steam_id": 774461
   },
@@ -329,7 +329,7 @@
     "img": "zeeple.jpg",
     "family_mode": true,
     "audience": false,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 10,
     "steam_id": 774461
   },
@@ -343,7 +343,7 @@
     "img": "patently.png",
     "family_mode": true,
     "audience": true,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 774461
   },
@@ -357,7 +357,7 @@
     "img": "tmp2.jpg",
     "family_mode": false,
     "audience": true,
-    "drawing": true,
+    "drawing": "occasionally",
     "game_length": 25,
     "steam_id": 1005300
   },
@@ -371,7 +371,7 @@
     "img": "role.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 1005300
   },
@@ -385,7 +385,7 @@
     "img": "joke.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 25,
     "steam_id": 1005300
   },
@@ -399,7 +399,7 @@
     "img": "dict.png",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 10,
     "steam_id": 1005300
   },
@@ -413,7 +413,7 @@
     "img": "push.jpg",
     "family_mode": true,
     "audience": false,
-    "drawing": true,
+    "drawing": "occasionally",
     "steam_id": 1005300
   },
   {
@@ -426,7 +426,7 @@
     "img": "quiplash3.webp",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 1211630
   },
@@ -440,7 +440,7 @@
     "img": "devils.webp",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 15,
     "steam_id": 1211630
   },
@@ -454,7 +454,7 @@
     "img": "champd.webp",
     "family_mode": true,
     "audience": true,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 1211630
   },
@@ -468,7 +468,7 @@
     "img": "talking.webp",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 30,
     "steam_id": 1211630
   },
@@ -482,7 +482,7 @@
     "img": "blather.webp",
     "family_mode": true,
     "audience": true,
-    "drawing": false,
+    "drawing": "no",
     "game_length": 30,
     "steam_id": 1211630
   },
@@ -496,7 +496,7 @@
     "img": "drawful2.jpg",
     "family_mode": true,
     "audience": true,
-    "drawing": true,
+    "drawing": "primarily",
     "game_length": 20,
     "steam_id": 442070
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ namespace Types {
     jbGames: any;
     filterChecks: any;
     onFilterChecksChange: any;
+    drawingSelect: any;
+    onDrawingSelectChange: any;
   }
 
   export interface GamesAppInterface extends GamesInterface {


### PR DESCRIPTION
Switched the "drawing" data point of each game from boolean to
"no", "occasionally", or "primarily", and switched the filter at
the top from a checkbox to a select dropdown. Added the logic to
handle the new filter (and removed old boolean/checkbox logic).

This allows filtering the list to show just games with drawing - it also allows filtering it to remove all games with drawing (some people have that preference), with fine controls so that games with just a little drawing (Trivia Murder Parties 1 & 2, Push the Button) can be left in if desired.